### PR TITLE
Fix infinite redirect loop with GitLab as OAuth provider

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var usernameKey = process.env['EP_OAUTH2_USERNAME_KEY'] || settings.users.oauth2
 var idKey = process.env['EP_OAUTH2_USERID_KEY'] || settings.users.oauth2.useridKey;
 var scope = process.env['EP_OAUTH2_SCOPE'] || settings.users.oauth2.scope;
 var proxy = process.env['EP_OAUTH2_PROXY'] || settings.users.oauth2.proxy;
+var state = process.env['EP_OAUTH2_STATE'] || settings.users.oauth2.state;
 
 passport.serializeUser(function(user, done) {
   done(null, user);
@@ -50,7 +51,8 @@ exports.expressConfigure = function(hook_name, context) {
     clientSecret: clientSecret,
     callbackURL: publicURL + '/auth/callback',
     scope: scope,
-    proxy: proxy
+    proxy: proxy,
+    state: state
   }, function(accessToken, refreshToken, profile, cb) {
     request.get({
       url: userinfoURL,

--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ exports.expressCreateServer = function (hook_name, context) {
 }
 
 exports.authenticate = function(hook_name, context) {
+  if (context.req.url.startsWith('/auth/')) return context.next();
   console.info('oauth2-authenticate from ->', context.req.url);
   context.req.session.afterAuthUrl = context.req.url;
   return passport.authenticate('hbp')(context.req, context.res, context.next);

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var publicURL = process.env['EP_OAUTH2_PUBLIC_URL'] || settings.users.oauth2.pub
 var userinfoURL = process.env['EP_OAUTH2_USERINFO_URL'] || settings.users.oauth2.userinfoURL;
 var usernameKey = process.env['EP_OAUTH2_USERNAME_KEY'] || settings.users.oauth2.usernameKey;
 var idKey = process.env['EP_OAUTH2_USERID_KEY'] || settings.users.oauth2.useridKey;
+var scope = process.env['EP_OAUTH2_SCOPE'] || settings.users.oauth2.scope;
 
 passport.serializeUser(function(user, done) {
   done(null, user);
@@ -46,7 +47,8 @@ exports.expressConfigure = function(hook_name, context) {
     tokenURL: tokenURL,
     clientID: clientID,
     clientSecret: clientSecret,
-    callbackURL: publicURL + '/auth/callback'
+    callbackURL: publicURL + '/auth/callback',
+    scope: scope
   }, function(accessToken, refreshToken, profile, cb) {
     request.get({
       url: userinfoURL,

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ var userinfoURL = process.env['EP_OAUTH2_USERINFO_URL'] || settings.users.oauth2
 var usernameKey = process.env['EP_OAUTH2_USERNAME_KEY'] || settings.users.oauth2.usernameKey;
 var idKey = process.env['EP_OAUTH2_USERID_KEY'] || settings.users.oauth2.useridKey;
 var scope = process.env['EP_OAUTH2_SCOPE'] || settings.users.oauth2.scope;
+var proxy = process.env['EP_OAUTH2_PROXY'] || settings.users.oauth2.proxy;
 
 passport.serializeUser(function(user, done) {
   done(null, user);
@@ -48,7 +49,8 @@ exports.expressConfigure = function(hook_name, context) {
     clientID: clientID,
     clientSecret: clientSecret,
     callbackURL: publicURL + '/auth/callback',
-    scope: scope
+    scope: scope,
+    proxy: proxy
   }, function(accessToken, refreshToken, profile, cb) {
     request.get({
       url: userinfoURL,

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ exports.expressCreateServer = function (hook_name, context) {
 }
 
 exports.authenticate = function(hook_name, context) {
-  if (context.req.url.startsWith('/auth/')) return context.next();
+  if (context.req.url.indexOf('/auth/') === 0) return context.next();
   console.info('oauth2-authenticate from ->', context.req.url);
   context.req.session.afterAuthUrl = context.req.url;
   return passport.authenticate('hbp')(context.req, context.res, context.next);


### PR DESCRIPTION
At the moment, it is not possible to use GitLab as an OAuth provider. Etherpad and GitLab end up in an infinite redirect loop, because etherpads `authenticate` hook is also called for the two registered routes in this plugin, see #1. This interferes with the OAuth handshake and the response code never reaches `passport-oauth`. Since Etherpad does not use any `/auth` routes, excluding them from authentication shouldn't be a problem. 

Also, to be actually useful in combination users might want to pass down additional options. I.e. GitLab will only accept OAuth challenges without a scope, if you grant full API access (which might make admins uncomfortable). In this PR I added support for scope, proxy (to allow deployment behind a reverse proxy), and state (to allow CSRF protection).

With this PR, `read_user` privileges granted on the GitLab's side, and the following configuration, the authentication via GitLab works fine for me:
```json
"users": {
  "oauth2": {
    "authorizationURL": "https://gitlab.com/oauth/authorize",
    "tokenURL": "https://gitlab.com/oauth/token",
    "clientID": "id",
    "clientSecret": "secret",
    "publicURL": "https://pad.example.com",
    "userinfoURL": "https://gitlab.com/api/v3/user",
    "usernameKey": "name",
    "useridKey": "username",
    "scope": "read_user",
    "proxy": true,
    "state": true
  }
},
```